### PR TITLE
Glossary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ python json_translate /home/user/project/locales/en_US.json --locale ES --output
 ### Optional parameters
 
 ```
--l, --locale    Target language to translate the file. Defaults to "en" (English)
--o, --output    Output file name. Defaults to "<target locale>.json" (ex: en.json)
--s, --sleep     Sleep time between API calls. Defaults to 0.01 (seconds)
--i, --indent    Output file indentation spaces. Defaults to 2
---encoding      Input & output file encoding. Defaults to UTF-8
---skip          Keys to skip in the json file (they won't be translated)
---log           Display translations as they are being translated
+-l, --locale          Target language to translate the file. Defaults to "en" (English)
+-sl, --source-locale  Source language translating from (Required for glossaries). Defaults to "en" (English)
+-g, --glossary        Glossary ID to use when translating (Optional)
+-o, --output          Output file name. Defaults to "<target locale>.json" (ex: en.json)
+-s, --sleep           Sleep time between API calls. Defaults to 0.01 (seconds)
+-i, --indent          Output file indentation spaces. Defaults to 2
+--encoding            Input & output file encoding. Defaults to UTF-8
+--skip                Keys to skip in the json file (they won't be translated)
+--log                 Display translations as they are being translated
 ```
 > Note that **sleep**, **indentation** and **encoding** can also be defined with variables in the `.env` file but they are overwritten with the values of the command.
 

--- a/json_translate/__main__.py
+++ b/json_translate/__main__.py
@@ -30,6 +30,8 @@ def main():
     )
     translator = DeepLTranslator(
         target_locale=lang_code.upper(),
+        source_locale=args.source_locale,
+        glossary=args.glossary,
         sleep=args.sleep,
         skip=args.skip,
         encoding=args.encoding,

--- a/json_translate/parser.py
+++ b/json_translate/parser.py
@@ -35,6 +35,17 @@ def get_parser(prog_name):
         help="Language target to translate",
     )
     parser.add_argument(
+        "-sl",
+        "--source-locale",
+        default="en",
+        help="Language translating from (required for glossary)",
+    )
+    parser.add_argument(
+        "-g",
+        "--glossary",
+        help="ID of glossary to use when translating",
+    )
+    parser.add_argument(
         "-o",
         "--output",
         default="en.json",

--- a/json_translate/translators/base.py
+++ b/json_translate/translators/base.py
@@ -15,6 +15,8 @@ class BaseTranslator(ABC):
     def __init__(
         self,
         target_locale: str,
+        source_locale: str,
+        glossary: str,
         skip: list = None,
         sleep: float = SLEEP_BETWEEN_API_CALLS,
         encoding: str = ENCODING,
@@ -31,6 +33,8 @@ class BaseTranslator(ABC):
         """
         self.skip_keys = skip or []
         self.target_locale = target_locale
+        self.source_locale = source_locale
+        self.glossary = glossary
         self.sleep = sleep
         self.encoding = encoding
         self.log_translations = log_translations

--- a/json_translate/translators/deepl.py
+++ b/json_translate/translators/deepl.py
@@ -34,14 +34,18 @@ class DeepLTranslator(BaseTranslator):
 
         time.sleep(self.sleep)
 
-        data = parse.urlencode(
-            {
-                "target_lang": self.target_locale,
-                "auth_key": os.environ.get("DEEPL_AUTH_KEY"),
-                "text": text,
-                "preserve_formatting": "1",
-            }
-        ).encode()
+        data = {
+            "target_lang": self.target_locale,
+            "source_lang": self.source_locale,
+            "auth_key": os.environ.get("DEEPL_AUTH_KEY"),
+            "text": text,
+            "preserve_formatting": "1"
+        }
+
+        if self.glossary != None:
+            data["glossary_id"] = self.glossary
+
+        data = parse.urlencode(data).encode()
 
         req = request.Request(DEEPL_API_ENDPOINT, data=data)
         response = request.urlopen(req)  # nosec


### PR DESCRIPTION
Added support for DeepL glossaries.

- added optional argument for setting the source locale as it is required when using a glossary. It defaults to en.
- added optional argument for setting the glossary id to be used when translating.
- updated README.md to add new parameters

I am not a Python developer, so I hope I didn't do something nonsensical.