### PR TITLE
fix: set source_locale and glossary as optional

### DIFF
--- a/json_translate/translators/base.py
+++ b/json_translate/translators/base.py
@@ -15,8 +15,8 @@ class BaseTranslator(ABC):
     def __init__(
         self,
         target_locale: str,
-        source_locale: str,
-        glossary: str,
+        source_locale: str = None,
+        glossary: str = None,
         skip: list = None,
         sleep: float = SLEEP_BETWEEN_API_CALLS,
         encoding: str = ENCODING,

--- a/json_translate/translators/deepl.py
+++ b/json_translate/translators/deepl.py
@@ -36,13 +36,15 @@ class DeepLTranslator(BaseTranslator):
 
         data = {
             "target_lang": self.target_locale,
-            "source_lang": self.source_locale,
             "auth_key": os.environ.get("DEEPL_AUTH_KEY"),
             "text": text,
-            "preserve_formatting": "1"
+            "preserve_formatting": "1",
         }
 
-        if self.glossary != None:
+        if self.source_locale is not None:
+            data["source_lang"] = self.source_locale
+
+        if self.glossary is not None:
             data["glossary_id"] = self.glossary
 
         data = parse.urlencode(data).encode()


### PR DESCRIPTION
- Define `BaseTranslator` args `source_locale` and `glossary` as optional (None by default)
- Only add `source_lang` and `glossary_id` to deepl request if they're defined.