### PR TITLE
fix(parser): remove default locale and use it as default file name

### DIFF
--- a/json_translate/argparser.py
+++ b/json_translate/argparser.py
@@ -44,7 +44,6 @@ def get_parser(prog_name) -> argparse.ArgumentParser:
     parser.add_argument(
         "-o",
         "--output",
-        default="en.json",
         help="Output file name",
     )
     parser.add_argument(

--- a/json_translate/files.py
+++ b/json_translate/files.py
@@ -78,7 +78,7 @@ def get_output_file(output: str, lang_code: str, input_file: str) -> str:
     :param input_file: input file
     :return: file to output translations
     """
-    output_file_name = output if output else f"{lang_code}.json"
+    output_file_name = output if output else f"{lang_code.lower()}.json"
 
     if not output_file_name.endswith(".json"):
         output_file_name += ".json"


### PR DESCRIPTION
The default value of the `--output` parameter interfered with its default assignment based on the chosen `--locale` language.

If you do not provide a value for `--output` it should default to <locale>.json.