### PR TITLE
fix: rename DEELP_SUPPORTED_LANGS typo to DEEPL_SUPPORTED_LANGS

### DIFF
--- a/json_translate/languages.py
+++ b/json_translate/languages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from settings import DEELP_SUPPORTED_LANGS, AWS_SUPPORTED_LANGS
+from settings import DEEPL_SUPPORTED_LANGS, AWS_SUPPORTED_LANGS
 
 
 def get_target_lang_code(service: str, locale: str) -> str:
@@ -16,7 +16,7 @@ def get_target_lang_code(service: str, locale: str) -> str:
             "Language code to translate to (usually 2 letters, unless a supported region like EN-GB): "
         )
 
-    if service == "deepl" and lang_code.upper() not in DEELP_SUPPORTED_LANGS:
+    if service == "deepl" and lang_code.upper() not in DEEPL_SUPPORTED_LANGS:
         # TODO: Log properly
         print(  # noqa: T201
             f"Language {lang_code} is not supported by DeepL.",

--- a/json_translate/settings.py
+++ b/json_translate/settings.py
@@ -23,7 +23,7 @@ ENCODING = os.getenv("ENCODING", "utf-8")
 
 # Supported language codes
 # fmt: off
-DEELP_SUPPORTED_LANGS = ( # https://www.deepl.com/docs-api/translate-text
+DEEPL_SUPPORTED_LANGS = ( # https://www.deepl.com/docs-api/translate-text
     "BG", "CS", "DA", "DE", "EL", "EN", "EN-GB", "EN-US", "ES", "ET", "FI", "FR", "HU", "ID",
     "IT", "JA", "KO", "LT", "LV", "NB", "NL", "PL", "PT-BR", "PT-PT", "RO", "RU", "SK",
     "SL", "SV", "TR", "UK", "ZH",


### PR DESCRIPTION
Fixed a typo I found while browsing: the constant `DEELP_SUPPORTED_LANGS` should be `DEEPL_SUPPORTED_LANGS`. The misspelled name was also referenced in `languages.py`, so I updated both.

**Before:**
```python
DEELP_SUPPORTED_LANGS = ( ... )
from settings import DEELP_SUPPORTED_LANGS, AWS_SUPPORTED_LANGS
```

**After:**
```python
DEEPL_SUPPORTED_LANGS = ( ... )
from settings import DEEPL_SUPPORTED_LANGS, AWS_SUPPORTED_LANGS
```

The constant still works the same way, it's just spelled correctly now. — Sent via @AmSach bot