### PR TITLE
fix: correct specifig typo to specific in docstrings

### DIFF
--- a/json_translate/translators/aws.py
+++ b/json_translate/translators/aws.py
@@ -33,7 +33,7 @@ class AWSTranslator(BaseTranslator):
         super().__init__(*args, **kwargs)
 
     def translate_string(self, text: str) -> str:
-        """Translate a specifig string.
+        """Translate a specific string.
 
         :param text: string to translate
         :return: string translation

--- a/json_translate/translators/deepl.py
+++ b/json_translate/translators/deepl.py
@@ -19,7 +19,7 @@ class DeepLTranslator(BaseTranslator):
         super().__init__(*args, **kwargs)
 
     def translate_string(self, text: str) -> str:
-        """Translate a specifig string.
+        """Translate a specific string.
 
         :param text: string to translate
         :return: string translation


### PR DESCRIPTION
Fixed two instances of the typo 'specifig' -> 'specific' in the docstrings of translate_string() in both DeepLTranslator (json_translate/translators/deepl.py) and AWSTranslator (json_translate/translators/aws.py).

### Before
```python
def translate_string(self, text: str) -> str:
    """Translate a specifig string.
    ...
```

### After
```python
def translate_string(self, text: str) -> str:
    """Translate a specific string.
    ...
```

— Sent via @AmSach bot